### PR TITLE
agent: support container userns inside the guest

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1202,6 +1202,7 @@ dependencies = [
  "oci",
  "once_cell",
  "rand",
+ "safe-path",
  "serde_json",
  "slog",
  "slog-scope",

--- a/src/agent/rustjail/src/validator.rs
+++ b/src/agent/rustjail/src/validator.rs
@@ -134,6 +134,13 @@ fn usernamespace(oci: &Spec) -> Result<()> {
         if !user_ns.exists() {
             return Err(anyhow!("user namespace not supported!"));
         }
+        // If the user namespace has already been persisted,
+        // there is no need to check the idmappings.
+        for ns in &linux.namespaces {
+            if ns.r#type.as_str() == "user" && !ns.path.is_empty() {
+                return Ok(());
+            }
+        }
         // check if idmappings is correct, at least I saw idmaps
         // with zero size was passed to agent
         idmapping(&linux.uid_mappings).context("idmapping uid")?;

--- a/src/dragonball/src/dbs_virtio_devices/src/fs/device.rs
+++ b/src/dragonball/src/dbs_virtio_devices/src/fs/device.rs
@@ -146,6 +146,7 @@ impl<AS: GuestAddressSpace> VirtioFs<AS> {
         handler: Box<dyn VirtioRegionHandler>,
         epoll_mgr: EpollManager,
         rate_limiter: Option<RateLimiter>,
+        id_mapping: (u32, u32, u32),
     ) -> Result<Self> {
         info!(
             "{}: tag {} req_num_queues {} queue_size {} cache_size {} cache_policy {} thread_pool_size {} writeback_cache {} no_open {} killpriv_v2 {} xattr {} drop_sys_resource {} no_readdir {}",
@@ -209,6 +210,7 @@ impl<AS: GuestAddressSpace> VirtioFs<AS> {
             no_open,
             killpriv_v2,
             no_readdir,
+            id_mapping,
             ..VfsOptions::default()
         };
 
@@ -1090,6 +1092,7 @@ pub mod tests {
             new_dummy_handler_helper(),
             epoll_manager.clone(),
             Some(rate_limiter),
+            (0, 0, 0),
         );
         assert!(res.is_err());
 
@@ -1111,6 +1114,7 @@ pub mod tests {
             new_dummy_handler_helper(),
             epoll_manager,
             Some(rate_limiter),
+            (0, 0, 0),
         );
         assert!(res.is_err());
     }
@@ -1135,6 +1139,7 @@ pub mod tests {
             new_dummy_handler_helper(),
             epoll_manager,
             Some(rate_limiter),
+            (0, 0, 0),
         )
         .unwrap();
 
@@ -1204,6 +1209,7 @@ pub mod tests {
                 new_dummy_handler_helper(),
                 epoll_manager.clone(),
                 Some(rate_limiter),
+                (0, 0, 0),
             )
             .unwrap();
 
@@ -1246,6 +1252,7 @@ pub mod tests {
                 new_dummy_handler_helper(),
                 epoll_manager,
                 Some(rate_limiter),
+                (0, 0, 0),
             )
             .unwrap();
 
@@ -1686,6 +1693,7 @@ pub mod tests {
             new_dummy_handler_helper(),
             epoll_manager,
             Some(rate_limiter),
+            (0, 0, 0),
         )
         .unwrap();
         let kvm = Kvm::new().unwrap();
@@ -1729,6 +1737,7 @@ pub mod tests {
             new_dummy_handler_helper(),
             epoll_manager,
             Some(rate_limiter),
+            (0, 0, 0),
         )
         .unwrap();
         let mut requirements = vec![
@@ -1772,6 +1781,7 @@ pub mod tests {
             new_dummy_handler_helper(),
             epoll_manager,
             Some(rate_limiter),
+            (0, 0, 0),
         )
         .unwrap();
         let kvm = Kvm::new().unwrap();

--- a/src/dragonball/src/dbs_virtio_devices/src/fs/handler.rs
+++ b/src/dragonball/src/dbs_virtio_devices/src/fs/handler.rs
@@ -681,6 +681,7 @@ pub mod tests {
             new_dummy_handler_helper(),
             epoll_manager,
             Some(rate_limiter),
+            (0, 0, 0),
         )
         .unwrap();
 

--- a/src/dragonball/src/device_manager/fs_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/fs_dev_mgr.rs
@@ -127,6 +127,8 @@ pub struct FsDeviceConfigInfo {
     pub use_shared_irq: Option<bool>,
     /// Use generic irq
     pub use_generic_irq: Option<bool>,
+    /// Declaration of the uid/gid mapping rules
+    pub id_mapping: (u32, u32, u32),
 }
 
 impl std::default::Default for FsDeviceConfigInfo {
@@ -149,6 +151,7 @@ impl std::default::Default for FsDeviceConfigInfo {
             rate_limiter: Some(RateLimiterConfigInfo::default()),
             use_shared_irq: None,
             use_generic_irq: None,
+            id_mapping: (0, 0, 0),
         }
     }
 }
@@ -420,6 +423,7 @@ impl FsDeviceMgr {
                 Box::new(handler),
                 epoll_mgr,
                 limiter,
+                config.id_mapping,
             )
             .map_err(FsDeviceError::CreateFsDevice)?,
         );

--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -82,6 +82,8 @@ pub const KATA_ANNO_CFG_AGENT_CONTAINER_PIPE_SIZE: &str =
     "io.katacontainers.config.agent.container_pipe_size";
 /// An annotation key to specify the size of the pipes created for containers.
 pub const CONTAINER_PIPE_SIZE_KERNEL_PARAM: &str = "agent.container_pipe_size";
+/// A sandbox annotation to enable shared userns.
+pub const KATA_ANNO_CFG_AGENT_GUEST_USERNS: &str = "io.katacontainers.config.agent.guest_userns";
 
 // Hypervisor related annotations
 /// Prefix for Hypervisor configurations.
@@ -910,6 +912,17 @@ impl Annotation {
                         }
                         Err(_e) => {
                             return Err(u32_err);
+                        }
+                    },
+                    KATA_ANNO_CFG_AGENT_GUEST_USERNS => match self.get_value::<bool>(key) {
+                        Ok(v) => {
+                            ag.guest_userns = v.unwrap_or_default();
+                            if ag.guest_userns {
+                                hv.shared_fs.virtio_fs_id_mapping = (0, 1, 65536);
+                            }
+                        }
+                        Err(_e) => {
+                            return Err(bool_err);
                         }
                     },
                     // update runtime config

--- a/src/libs/kata-types/src/config/agent.rs
+++ b/src/libs/kata-types/src/config/agent.rs
@@ -82,6 +82,10 @@ pub struct Agent {
     /// container pipe size
     #[serde(default)]
     pub container_pipe_size: u32,
+
+    /// If enabled, the agent will creates a rootless shared userns for the containers to use.
+    #[serde(default)]
+    pub guest_userns: bool,
 }
 
 impl std::default::Default for Agent {
@@ -98,6 +102,7 @@ impl std::default::Default for Agent {
             health_check_request_timeout_ms: 90_000,
             kernel_modules: Default::default(),
             container_pipe_size: 0,
+            guest_userns: false,
         }
     }
 }

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -850,6 +850,12 @@ pub struct SharedFsInfo {
     /// This is the msize used for 9p shares. It is the number of bytes used for 9p packet payload.
     #[serde(default)]
     pub msize_9p: u32,
+
+    /// Declaration of ID mapping, in the format (internal ID, external ID, range).
+    /// For example, (0, 1, 65536) represents mapping the external UID/GID range of `1~65536`
+    /// to the range of `0~65535` within the virtio-fs.
+    #[serde(default)]
+    pub virtio_fs_id_mapping: (u32, u32, u32),
 }
 
 impl SharedFsInfo {

--- a/src/libs/protocols/protos/agent.proto
+++ b/src/libs/protocols/protos/agent.proto
@@ -298,6 +298,8 @@ message CreateSandboxRequest {
 	string guest_hook_path = 6;
 	// This field is the list of kernel modules to be loaded in the guest kernel.
 	repeated KernelModule kernel_modules = 7;
+	// Indicates the need to create a rootless shared userns for containers to use.
+	bool guest_userns = 8;
 }
 
 message DestroySandboxRequest {

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -1057,8 +1057,6 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 [[package]]
 name = "fuse-backend-rs"
 version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85357722be4bf3d0b7548bedf7499686c77628c2c61cb99c6519463f7a9e5f0"
 dependencies = [
  "arc-swap",
  "bitflags 1.3.2",

--- a/src/runtime-rs/Cargo.toml
+++ b/src/runtime-rs/Cargo.toml
@@ -4,3 +4,6 @@ members = [
     "crates/shim-ctl",
 ]
 
+[patch.crates-io]
+fuse-backend-rs = { path = "/root/repo/fuse-backend-rs" }
+

--- a/src/runtime-rs/crates/agent/src/kata/trans.rs
+++ b/src/runtime-rs/crates/agent/src/kata/trans.rs
@@ -657,6 +657,7 @@ impl From<CreateSandboxRequest> for agent::CreateSandboxRequest {
             sandbox_id: from.sandbox_id,
             guest_hook_path: from.guest_hook_path,
             kernel_modules: trans_vec(from.kernel_modules),
+            guest_userns: from.guest_userns,
             ..Default::default()
         }
     }

--- a/src/runtime-rs/crates/agent/src/types.rs
+++ b/src/runtime-rs/crates/agent/src/types.rs
@@ -473,6 +473,7 @@ pub struct CreateSandboxRequest {
     pub sandbox_id: String,
     pub guest_hook_path: String,
     pub kernel_modules: Vec<KernelModule>,
+    pub guest_userns: bool,
 }
 
 #[derive(PartialEq, Clone, Default)]

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_fs.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_fs.rs
@@ -70,6 +70,9 @@ pub struct ShareFsDeviceConfig {
 
     /// options: virtiofs device's config options.
     pub options: Vec<String>,
+
+    /// declaration of the uid/gid mapping rules
+    pub id_mapping: (u32, u32, u32),
 }
 
 #[derive(Debug, Clone)]

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
@@ -326,6 +326,7 @@ impl DragonballInner {
             cache_size: (self.config.shared_fs.virtio_fs_cache_size as u64)
                 .saturating_mul(MB_TO_B as u64),
             xattr: true,
+            id_mapping: config.id_mapping,
             ..Default::default()
         };
 

--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs.rs
@@ -39,6 +39,7 @@ pub(crate) async fn prepare_virtiofs(
     fs_type: &str,
     id: &str,
     root: &str,
+    id_mapping: (u32, u32, u32),
 ) -> Result<()> {
     let host_ro_dest = utils::get_host_ro_shared_path(id);
     utils::ensure_dir_exist(&host_ro_dest)?;
@@ -58,6 +59,7 @@ pub(crate) async fn prepare_virtiofs(
             queue_size: 0,
             queue_num: 0,
             options: vec![],
+            id_mapping,
         },
     };
     h.add_device(DeviceType::ShareFs(share_fs_device))

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -342,6 +342,7 @@ impl Sandbox for VirtSandbox {
                 .security_info
                 .guest_hook_path,
             kernel_modules,
+            guest_userns: agent_config.guest_userns,
         };
 
         self.agent


### PR DESCRIPTION
The mount operation within the container only requires SYS_ADMIN capability in the mount namespace, not system-level SYS_ADMIN privileges. Thus, a shared userns can be created within the guest, remapping the root inside the userns to a non-root user on the guest.

Fixes: #6715